### PR TITLE
Update to fahclient_7.6.13

### DIFF
--- a/foldingathome/Dockerfile
+++ b/foldingathome/Dockerfile
@@ -9,7 +9,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG BUILD_ARCH=amd64
 RUN \
     curl -J -L -o /tmp/fah.deb \
-        "https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.5/fahclient_7.5.1_amd64.deb" \
+        "https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.6/fahclient_7.6.9_amd64.deb" \
     \
     && apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/foldingathome/Dockerfile
+++ b/foldingathome/Dockerfile
@@ -9,7 +9,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG BUILD_ARCH=amd64
 RUN \
     curl -J -L -o /tmp/fah.deb \
-        "https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.6/fahclient_7.6.9_amd64.deb" \
+        "https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.6/fahclient_7.6.13_amd64.deb" \
     \
     && apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
# Proposed Changes

Update to 7.6.13 (https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.6/)

No test have been done.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<blockquote><div><strong><a href="https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.6/">Index of /releases/public/release/fahclient/debian-stable-64bit/v7.6/</a></strong></div></blockquote>