### PR TITLE
Aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-[aarch64-shield]: https://img.shields.io/badge/aarch64-no-red.svg
+[aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
 [armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-no-red.svg

--- a/foldingathome/Dockerfile
+++ b/foldingathome/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:5.2.2
+ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:5.2.3
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -7,9 +7,17 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base system
 ARG BUILD_ARCH=amd64
+ARG FAH_VERSION=7.6.21
+ARG FAH_VERSION_MAJOR=v7.6
+ARG FAH_CLIENT_BITS=64bit
+ARG FAH_DEB_ARCH=amd64
+
 RUN \
-    curl -J -L -o /tmp/fah.deb \
-        "https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.6/fahclient_7.6.21_amd64.deb" \
+    if [ ${BUILD_ARCH} == "aarch64" ];then FAH_DEB_ARCH=arm64;FAH_CLIENT_BITS=arm64;fi \
+    && DEB="https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-${FAH_CLIENT_BITS}/${FAH_VERSION_MAJOR}/fahclient_${FAH_VERSION}_${FAH_DEB_ARCH}.deb" \
+    && echo ${DEB} \
+    && curl -J -L -o /tmp/fah.deb \
+        "${DEB}" \
     \
     && apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/foldingathome/build.yaml
+++ b/foldingathome/build.yaml
@@ -1,3 +1,4 @@
 ---
 build_from:
-  amd64: ghcr.io/hassio-addons/debian-base/amd64:5.2.2
+  amd64: ghcr.io/hassio-addons/debian-base/amd64:5.2.3
+  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:5.2.3

--- a/foldingathome/config.yaml
+++ b/foldingathome/config.yaml
@@ -7,6 +7,7 @@ url: https://github.com/hassio-addons/addon-foldingathome
 webui: http://[HOST]:[PORT:7396]
 arch:
   - amd64
+  - aarch64
 init: false
 hassio_api: true
 video: true


### PR DESCRIPTION
# Proposed Changes

Add aarch64, Tested and built on amd64(HP Micro server Debian Linux) and Pi3(HassOS).

## Related Issues

Resolves #7 & #37 
