### PR TITLE
✏️ Update references to ARM being unsupported

### DIFF
--- a/foldingathome/DOCS.md
+++ b/foldingathome/DOCS.md
@@ -81,8 +81,7 @@ panel_iframe:
 
 ## Known issues and limitations
 
-- This add-on only runs on 64-bits intel-based computers. Folding@home does
-  not support ARM devices (e.g., a Raspberry Pi).
+- This add-on only runs on 64-bits intel-based computers.
 
 ## Changelog & Releases
 


### PR DESCRIPTION
# Proposed Changes

Folding@Home looks to have supported ARM towards the end of 2020 (post addon setup), remove the statement saying it isn't supported.

## Related Issues

Closes #71 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated supported platforms information for the Folding@home add-on, removing the mention that ARM devices like Raspberry Pi are not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->