### PR TITLE
Update Folding@home app for v8.5.5 client + add user/team/passkey + account-token linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Fighting disease with a world wide distributed super computer.
 - Defaults set credit identity for the **Home Assistant Folding@home team (247478)** using `Anonymous`.
 - Optional: set `user`, `team`, and `passkey` to receive credit under your own donor identity.
 - Note: anonymous/headless folding has not been tested end-to-end in this update. For predictable startup and remote control, it is recommended to provide `account_token` (and optionally `machine_name`).
-- Optional: set `account_token` (and `machine_name`) to link the node to your Folding@home account for the v8-5 Web Control machine list.
+- Optional: set `account_token` (and `machine_name`) to link the node to your Folding@home account for the v8.5 Web Control machine list.
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ Fighting disease with a world wide distributed super computer.
 ## Configuration highlights
 
 - The add-on runs the Folding@home v8 client and exposes the local Web UI on port **7396**.
-- Defaults contribute to the **Home Assistant Folding@home team (247478)** using `Anonymous`.
+- Defaults set credit identity for the **Home Assistant Folding@home team (247478)** using `Anonymous`.
 - Optional: set `user`, `team`, and `passkey` to receive credit under your own donor identity.
+- Note: anonymous/headless folding has not been tested end-to-end in this update. For predictable startup and remote control, it is recommended to provide `account_token` (and optionally `machine_name`).
 - Optional: set `account_token` (and `machine_name`) to link the node to your Folding@home account for the v8-5 Web Control machine list.
 
 ## About

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Fighting disease with a world wide distributed super computer.
 
 ![Folding@home in the Home Assistant Frontend](images/screenshot.png)
 
+## Configuration highlights
+
+- The add-on runs the Folding@home v8 client and exposes the local Web UI on port **7396**.
+- Defaults contribute to the **Home Assistant Folding@home team (247478)** using `Anonymous`.
+- Optional: set `user`, `team`, and `passkey` to receive credit under your own donor identity.
+- Optional: set `account_token` (and `machine_name`) to link the node to your Folding@home account for the v8-5 Web Control machine list.
+
 ## About
 
 Folding@home (FAH or F@h) is a distributed computing project for performing

--- a/foldingathome/Dockerfile
+++ b/foldingathome/Dockerfile
@@ -7,6 +7,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base system
 ARG BUILD_ARCH=amd64
+ARG FAH_CLIENT_SHA256=""
 RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -14,9 +15,15 @@ RUN \
         curl \
         bzip2 \
         ocl-icd-libopencl1 \
+        coreutils \
     \
     && curl -fSL -o /tmp/fah.deb \
         "https://download.foldingathome.org/releases/public/fah-client/debian-10-64bit/release/fah-client_8.5.5_amd64.deb" \
+    && if [[ -n "${FAH_CLIENT_SHA256}" ]]; then \
+         echo "${FAH_CLIENT_SHA256}  /tmp/fah.deb" | sha256sum -c -; \
+       else \
+         echo "WARNING: FAH_CLIENT_SHA256 not set; skipping checksum verification" >&2; \
+       fi \
     \
     && addgroup --system render \
     && mkdir -p /etc/fahclient \

--- a/foldingathome/Dockerfile
+++ b/foldingathome/Dockerfile
@@ -8,21 +8,24 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Setup base system
 ARG BUILD_ARCH=amd64
 RUN \
-    curl -J -L -o /tmp/fah.deb \
-        "https://download.foldingathome.org/releases/public/fah-client/debian-10-64bit/release/fah-client_8.3.17_amd64.deb" \
-    \
-    && apt-get update \
+    apt-get update \
     && apt-get install -y --no-install-recommends \
-        bzip2=1.0.8-5+b1 \
-        ocl-icd-libopencl1=2.3.1-1 \
+        ca-certificates \
+        curl \
+        bzip2 \
+        ocl-icd-libopencl1 \
+    \
+    && curl -fSL -o /tmp/fah.deb \
+        "https://download.foldingathome.org/releases/public/fah-client/debian-10-64bit/release/fah-client_8.5.5_amd64.deb" \
     \
     && addgroup --system render \
-    && mkdir /etc/fahclient \
+    && mkdir -p /etc/fahclient \
     && touch /etc/fahclient/config.xml \
-    && dpkg --install /tmp/fah.deb \
+    && apt-get install -y --no-install-recommends /tmp/fah.deb \
+    && dpkg -s fah-client | grep -q "^Version: 8.5.5" \
+    && ln -sf /usr/bin/fah-client /usr/bin/FAHClient \
     \
     && rm -fr \
-        /etc/fahclient \
         /tmp/* \
         /var/{cache,log}/* \
         /var/lib/apt/lists/*
@@ -34,6 +37,9 @@ COPY rootfs /
 ARG BUILD_DATE
 ARG BUILD_REF
 ARG BUILD_VERSION
+ARG BUILD_NAME="Folding@home"
+ARG BUILD_DESCRIPTION="Fighting disease with a world wide distributed super computer"
+ARG BUILD_REPOSITORY="hassio-addons/addon-foldingathome"
 
 # Labels
 LABEL \
@@ -41,7 +47,7 @@ LABEL \
     io.hass.description="${BUILD_DESCRIPTION}" \
     io.hass.arch="${BUILD_ARCH}" \
     io.hass.type="addon" \
-    io.hass.version=${BUILD_VERSION} \
+    io.hass.version="${BUILD_VERSION}" \
     maintainer="Franck Nijhof <frenck@addons.community>" \
     org.opencontainers.image.title="${BUILD_NAME}" \
     org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
@@ -51,6 +57,6 @@ LABEL \
     org.opencontainers.image.url="https://addons.community" \
     org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
     org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
-    org.opencontainers.image.created=${BUILD_DATE} \
-    org.opencontainers.image.revision=${BUILD_REF} \
-    org.opencontainers.image.version=${BUILD_VERSION}
+    org.opencontainers.image.created="${BUILD_DATE}" \
+    org.opencontainers.image.revision="${BUILD_REF}" \
+    org.opencontainers.image.version="${BUILD_VERSION}"

--- a/foldingathome/config.yaml
+++ b/foldingathome/config.yaml
@@ -4,7 +4,6 @@ version: dev
 slug: foldingathome
 description: Fighting disease with a world wide distributed super computer
 url: https://github.com/hassio-addons/addon-foldingathome
-codenotary: codenotary@frenck.dev
 webui: http://[HOST]:[PORT:7396]
 arch:
   - amd64
@@ -13,17 +12,21 @@ hassio_api: true
 video: true
 ports:
   7396/tcp: 7396
-  36330/tcp: null
 ports_description:
   7396/tcp: Web interface
-  36330/tcp: Remote command interface
 
 options:
   log_level: info
+  user: "Anonymous"
+  team: 247478
+  passkey: ""
   account_token: ""
   machine_name: "homeassistant"
 
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
+  user: str?
+  team: int?
+  passkey: str?
   account_token: str?
   machine_name: str?

--- a/foldingathome/config.yaml
+++ b/foldingathome/config.yaml
@@ -17,3 +17,13 @@ ports:
 ports_description:
   7396/tcp: Web interface
   36330/tcp: Remote command interface
+
+options:
+  log_level: info
+  account_token: ""
+  machine_name: "homeassistant"
+
+schema:
+  log_level: list(trace|debug|info|notice|warning|error|fatal)?
+  account_token: str?
+  machine_name: str?

--- a/foldingathome/rootfs/etc/s6-overlay/s6-rc.d/fah/run
+++ b/foldingathome/rootfs/etc/s6-overlay/s6-rc.d/fah/run
@@ -32,16 +32,29 @@ cd /data || bashio::exit.nok "Failed to change to working directory"
 
 CONFIG_FILE="/data/config.xml"
 
+xml_escape() {
+  local value="$1"
+  value=${value//&/&amp;}
+  value=${value//</&lt;}
+  value=${value//>/&gt;}
+  value=${value//\"/&quot;}
+  value=${value//\'/&apos;}
+  printf '%s' "${value}"
+}
+
 # Only write config.xml when linking to an account (v8-5 web control machine linking).
 # For anonymous/default runs, do not force a config.xml (v8.5.5 does not support fold-anon here).
 if [[ -n "${ACCOUNT_TOKEN}" ]]; then
   bashio::log.info "Writing ${CONFIG_FILE} (account linked)"
   {
     echo "<config>"
-    echo "  <account-token v=\"${ACCOUNT_TOKEN}\"/>"
-    echo "  <machine-name v=\"${MACHINE_NAME}\"/>"
+    echo "  <account-token v=\"$(xml_escape "${ACCOUNT_TOKEN}")\"/>"
+    echo "  <machine-name v=\"$(xml_escape "${MACHINE_NAME}")\"/>"
     echo "</config>"
   } > "${CONFIG_FILE}"
+  chmod 600 "${CONFIG_FILE}"
+else
+  rm -f "${CONFIG_FILE}"
 fi
 
 # Log args, but redact passkey to avoid leaking secrets into add-on logs

--- a/foldingathome/rootfs/etc/s6-overlay/s6-rc.d/fah/run
+++ b/foldingathome/rootfs/etc/s6-overlay/s6-rc.d/fah/run
@@ -9,6 +9,9 @@ declare -a options
 
 bashio::log.info 'Starting Folding@home...'
 
+ACCOUNT_TOKEN="$(bashio::config 'account_token')"
+MACHINE_NAME="$(bashio::config 'machine_name')"
+
 options+=(--http-addresses 0.0.0.0:7396)
 options+=(--command-address 0.0.0.0)
 options+=(--command-port 36330)
@@ -21,4 +24,36 @@ options+=(--team 247478)
 options+=(--power full)
 
 cd /data || bashio::exit.nok "Failed to change to working directory"
+
+# If an account token is provided, ensure /data/config.xml contains it so the node appears in v8-5 web control
+if [[ -n "${ACCOUNT_TOKEN}" ]]; then
+  CONFIG_FILE="/data/config.xml"
+
+  if [[ ! -f "${CONFIG_FILE}" ]] || ! grep -q "</config>" "${CONFIG_FILE}"; then
+    bashio::log.info "Creating ${CONFIG_FILE} with account-token and machine-name"
+    cat > "${CONFIG_FILE}" <<EOF
+<config>
+  <account-token v="${ACCOUNT_TOKEN}"/>
+  <machine-name v="${MACHINE_NAME}"/>
+</config>
+EOF
+  else
+    bashio::log.info "Updating ${CONFIG_FILE} with account-token and machine-name"
+
+    tmpfile="$(mktemp)"
+    grep -v -E "<account-token |<machine-name " "${CONFIG_FILE}" > "${tmpfile}" || true
+
+    awk -v token="${ACCOUNT_TOKEN}" -v name="${MACHINE_NAME}" '
+      /<\/config>/ && !inserted {
+        print "  <account-token v=\"" token "\"/>";
+        print "  <machine-name v=\"" name "\"/>";
+        inserted=1;
+      }
+      { print }
+    ' "${tmpfile}" > "${CONFIG_FILE}"
+
+    rm -f "${tmpfile}"
+  fi
+fi
+
 exec FAHClient "${options[@]}"

--- a/foldingathome/rootfs/etc/s6-overlay/s6-rc.d/fah/run
+++ b/foldingathome/rootfs/etc/s6-overlay/s6-rc.d/fah/run
@@ -12,48 +12,56 @@ bashio::log.info 'Starting Folding@home...'
 ACCOUNT_TOKEN="$(bashio::config 'account_token')"
 MACHINE_NAME="$(bashio::config 'machine_name')"
 
+FAH_USER="$(bashio::config 'user')"
+FAH_TEAM="$(bashio::config 'team')"
+FAH_PASSKEY="$(bashio::config 'passkey')"
+
 options+=(--http-addresses 0.0.0.0:7396)
-options+=(--command-address 0.0.0.0)
-options+=(--command-port 36330)
-options+=(--command-allow-no-pass 0/0)
 options+=(--allow 0/0)
-options+=(--web-allow 0/0)
-options+=(--smp=true)
-options+=(--user "Anonymous")
-options+=(--team 247478)
-options+=(--power full)
+
+options+=(--user "${FAH_USER}")
+options+=(--team "${FAH_TEAM}")
+
+# Passkey is optional
+if [[ -n "${FAH_PASSKEY}" ]]; then
+  options+=(--passkey "${FAH_PASSKEY}")
+fi
+
 
 cd /data || bashio::exit.nok "Failed to change to working directory"
 
-# If an account token is provided, ensure /data/config.xml contains it so the node appears in v8-5 web control
+CONFIG_FILE="/data/config.xml"
+
+# Only write config.xml when linking to an account (v8-5 web control machine linking).
+# For anonymous/default runs, do not force a config.xml (v8.5.5 does not support fold-anon here).
 if [[ -n "${ACCOUNT_TOKEN}" ]]; then
-  CONFIG_FILE="/data/config.xml"
-
-  if [[ ! -f "${CONFIG_FILE}" ]] || ! grep -q "</config>" "${CONFIG_FILE}"; then
-    bashio::log.info "Creating ${CONFIG_FILE} with account-token and machine-name"
-    cat > "${CONFIG_FILE}" <<EOF
-<config>
-  <account-token v="${ACCOUNT_TOKEN}"/>
-  <machine-name v="${MACHINE_NAME}"/>
-</config>
-EOF
-  else
-    bashio::log.info "Updating ${CONFIG_FILE} with account-token and machine-name"
-
-    tmpfile="$(mktemp)"
-    grep -v -E "<account-token |<machine-name " "${CONFIG_FILE}" > "${tmpfile}" || true
-
-    awk -v token="${ACCOUNT_TOKEN}" -v name="${MACHINE_NAME}" '
-      /<\/config>/ && !inserted {
-        print "  <account-token v=\"" token "\"/>";
-        print "  <machine-name v=\"" name "\"/>";
-        inserted=1;
-      }
-      { print }
-    ' "${tmpfile}" > "${CONFIG_FILE}"
-
-    rm -f "${tmpfile}"
-  fi
+  bashio::log.info "Writing ${CONFIG_FILE} (account linked)"
+  {
+    echo "<config>"
+    echo "  <account-token v=\"${ACCOUNT_TOKEN}\"/>"
+    echo "  <machine-name v=\"${MACHINE_NAME}\"/>"
+    echo "</config>"
+  } > "${CONFIG_FILE}"
 fi
 
-exec FAHClient "${options[@]}"
+# Log args, but redact passkey to avoid leaking secrets into add-on logs
+log_args=()
+skip_next=false
+for arg in "${options[@]}"; do
+  if ${skip_next}; then
+    log_args+=("********")
+    skip_next=false
+    continue
+  fi
+
+  if [[ "${arg}" == "--passkey" ]]; then
+    log_args+=("--passkey")
+    skip_next=true
+    continue
+  fi
+
+  log_args+=("${arg}")
+done
+
+bashio::log.info "FAHClient args: ${log_args[*]}"
+exec /usr/bin/FAHClient "${options[@]}"

--- a/foldingathome/rootfs/etc/s6-overlay/s6-rc.d/fah/run
+++ b/foldingathome/rootfs/etc/s6-overlay/s6-rc.d/fah/run
@@ -58,10 +58,6 @@ if [[ -n "${ACCOUNT_TOKEN}" ]]; then
 else
   rm -f "${CONFIG_FILE}"
 fi
-  } > "${CONFIG_FILE}"
-  chmod 600 "${CONFIG_FILE}"
-else
-  rm -f "${CONFIG_FILE}"
 fi
 
 # Log args, but redact passkey to avoid leaking secrets into add-on logs

--- a/foldingathome/rootfs/etc/s6-overlay/s6-rc.d/fah/run
+++ b/foldingathome/rootfs/etc/s6-overlay/s6-rc.d/fah/run
@@ -58,7 +58,6 @@ if [[ -n "${ACCOUNT_TOKEN}" ]]; then
 else
   rm -f "${CONFIG_FILE}"
 fi
-fi
 
 # Log args, but redact passkey to avoid leaking secrets into add-on logs
 log_args=()

--- a/foldingathome/rootfs/etc/s6-overlay/s6-rc.d/fah/run
+++ b/foldingathome/rootfs/etc/s6-overlay/s6-rc.d/fah/run
@@ -49,8 +49,15 @@ if [[ -n "${ACCOUNT_TOKEN}" ]]; then
   {
     echo "<config>"
     echo "  <account-token v=\"$(xml_escape "${ACCOUNT_TOKEN}")\"/>"
-    echo "  <machine-name v=\"$(xml_escape "${MACHINE_NAME}")\"/>"
+    if [[ -n "${MACHINE_NAME}" ]]; then
+      echo "  <machine-name v=\"$(xml_escape "${MACHINE_NAME}")\"/>"
+    fi
     echo "</config>"
+  } > "${CONFIG_FILE}"
+  chmod 600 "${CONFIG_FILE}"
+else
+  rm -f "${CONFIG_FILE}"
+fi
   } > "${CONFIG_FILE}"
   chmod 600 "${CONFIG_FILE}"
 else


### PR DESCRIPTION
## Summary
This PR revives the Folding@home add-on by updating the packaged client to **Folding@home v8.5.5** and aligning add-on startup/configuration with the current client behavior.

## Key changes
- Update FAH client package to **8.5.5** and verify the installed version at build time.
- Ensure the `FAHClient` command exists by symlinking Debian’s `fah-client` binary (`/usr/bin/fah-client` → `/usr/bin/FAHClient`).
- Add new add-on configuration options:
  - `user` (default: `Anonymous`)
  - `team` (default: `247478`)
  - `passkey` (optional)
  - `account_token` (optional; links the node to your Folding@home account for the v8-5 Web Control machine list)
  - `machine_name` (optional)
- Update startup script to:
  - pass `user` / `team` / `passkey` via CLI
  - write `/data/config.xml` only when `account_token` is provided (account linking + machine name)
  - redact `passkey` in add-on logs
- Remove deprecated `codenotary` key from add-on metadata.
- Remove unused legacy command-interface port (`36330/tcp`), since the v8.5.5 packaging in this add-on does not expose that interface.

## User-facing behavior
- Defaults still set credit identity for the **Home Assistant Folding@home team** (`Anonymous`, team `247478`).
- **Anonymous/headless folding has not been tested end-to-end in this PR.** For predictable startup, remote control, and for the node to appear in the v8-5 Web Control machine list, it is **recommended** that users provide `account_token` (and optionally `machine_name`), and configure `user/team/passkey` for their donor identity.

## Testing
Tested on:
- Home Assistant OS 17.1 (amd64 / generic-x86-64)
- Supervisor 2026.02.3, Core 2026.2.3

Verified:
- add-on builds locally and starts
- links to account via token (`Account linked`)
- requests/receives WUs and downloads/validates cores
- FahCore runs and begins stepping
- Web UI reachable on port **7396**

## Development note
Implemented with assistance from ChatGPT, then reviewed and tested end-to-end on HAOS amd64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Optional account linking via account_token and machine_name; configurable user, team, and passkey for credited identity; local Web UI remains on port 7396.

* **Documentation**
  - Added "Configuration highlights" covering defaults, personalization, anonymous/headless notes, and recommendation to supply account_token.

* **Chores**
  - Upgraded Folding@home client to v8.5.x and improved installation/startup flow and build metadata.

* **Security**
  - Safer config generation and log redaction for sensitive credentials.

* **Behavior Change**
  - Removed legacy remote command interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->